### PR TITLE
#16 - Adding Flutter Linter Rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,91 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
-include: package:flutter_lints/flutter.yaml
-
 linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at https://dart.dev/lints.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    - avoid_empty_else
+    - avoid_relative_lib_imports
+    - avoid_shadowing_type_parameters
+    - avoid_types_as_parameter_names
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - collection_methods_unrelated_type
+    - curly_braces_in_flow_control_structures
+    - dangling_library_doc_comments
+    - depend_on_referenced_packages
+    - empty_catches
+    - file_names
+    - hash_and_equals
+    - implicit_call_tearoffs
+    - no_duplicate_case_values
+    - non_constant_identifier_names
+    - null_check_on_nullable_type_parameter
+    - package_prefixed_library_names
+    - prefer_generic_function_type_aliases
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
+    - secure_pubspec_urls
+    - type_literal_in_constant_pattern
+    - unnecessary_overrides
+    - unrelated_type_equality_checks
+    - use_string_in_part_of_directives
+    - valid_regexps
+    - void_checks
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+    # 
+    - annotate_overrides
+    - avoid_function_literals_in_foreach_calls
+    - avoid_init_to_null
+    - avoid_null_checks_in_equality_operators
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    - avoid_returning_null_for_void
+    - avoid_single_cascade_in_expression_statements
+    - constant_identifier_names
+    - control_flow_in_finally
+    - empty_constructor_bodies
+    - empty_statements
+    - exhaustive_cases
+    - implementation_imports
+    - library_names
+    - library_prefixes
+    - library_private_types_in_public_api
+    - no_leading_underscores_for_library_prefixes
+    - no_leading_underscores_for_local_identifiers
+    - null_closures
+    - overridden_fields
+    - package_names
+    - prefer_adjacent_string_concatenation
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_contains
+    - prefer_final_fields
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_function_declarations_over_variables
+    - prefer_if_null_operators
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    - prefer_interpolation_to_compose_strings
+    - prefer_is_not_operator
+    - prefer_null_aware_operators
+    - prefer_spread_collections
+    - recursive_getters
+    - slash_for_doc_comments
+    - type_init_formals
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_constructor_name
+    - unnecessary_getters_setters
+    - unnecessary_late
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
+    - unnecessary_this
+    - unnecessary_to_list_in_spreads
+    - use_function_type_syntax_for_parameters
+    - use_rethrow_when_possible
+    - use_super_parameters

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,78 +1,198 @@
 linter:
   rules:
     - avoid_empty_else
+
+    # When mixing relative and absolute imports it’s possible to create confusion where the same member gets imported in two different ways. An easy way to avoid that is to ensure you have no relative imports that include lib/ in their paths.
     - avoid_relative_lib_imports
-    - avoid_shadowing_type_parameters
+
+    # AVOID using a parameter name that is the same as an existing type.
     - avoid_types_as_parameter_names
+
+    # AVOID using await on anything which is not a future.
+    # Await is allowed on the types: Future<X>, FutureOr<X>, Future<X>?, FutureOr<X>? and dynamic.
+    # Further, using await null is specifically allowed as a way to introduce a microtask delay.
     - await_only_futures
+
+    # DO name extensions using UpperCamelCase. Extensions should capitalize the first letter of each word (including the first word), and use no separators.
     - camel_case_extensions
+
+    # DO name types using UpperCamelCase. 
+    # Classes and typedefs should capitalize the first letter of each word (including the first word), and use no separators.
     - camel_case_types
+
+    # DON’T invoke certain collection method with an argument with an unrelated type.
     - collection_methods_unrelated_type
     - curly_braces_in_flow_control_structures
-    - dangling_library_doc_comments
+
+    # DO depend on referenced packages. When importing a package, add a dependency on it to the pubspec.
     - depend_on_referenced_packages
+
+    # In general, empty catch blocks should be avoided. 
+    # In cases where they are intended, a comment should be provided to explain why exceptions are being caught and suppressed. 
+    # Alternatively, the exception identifier can be named with underscores (e.g., _) to indicate that we intend to skip it.
     - empty_catches
+
+    # DO name source files using lowercase_with_underscores
     - file_names
+
+    # Every object in Dart has a hashCode. Both the == operator and the hashCode property of objects must be consistent in order for a common hash map implementation to function properly. 
+    # Thus, when overriding ==, the hashCode should also be overridden to maintain consistency. Similarly, if hashCode is overridden, == should be also.
     - hash_and_equals
-    - implicit_call_tearoffs
+
+    # Don't use more than one case with same value.
     - no_duplicate_case_values
+
+    # Name non-constant identifiers using lowerCamelCase.
     - non_constant_identifier_names
+
+    # Don't use null check on a potentially nullable type parameter.
     - null_check_on_nullable_type_parameter
+
+    # Prefix library names with the package name and a dot-separated path.
     - package_prefixed_library_names
-    - prefer_generic_function_type_aliases
+
+    # Use isEmpty for Iterables and Maps.
+    # Use isNotEmpty for Iterables and Maps.
     - prefer_is_empty
     - prefer_is_not_empty
+
+    # Prefer to use whereType on iterable.
     - prefer_iterable_whereType
+
+    # PREFER specifying a type annotation for uninitialized variables and fields.
     - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
+
+    # DO Use secure urls in pubspec.yaml.
+    # Use https instead of http or git
     - secure_pubspec_urls
+
+    # If you meant to test if the object has type Foo, instead write Foo _.
     - type_literal_in_constant_pattern
+
+    # Don't override a method to do a super method invocation with the same parameters.
     - unnecessary_overrides
+
+    # Comparing references of a type where neither is a subtype of the other most likely will return false and might not reflect programmer’s intent.
     - unrelated_type_equality_checks
+
+    # DO use strings in `part of` directives.
     - use_string_in_part_of_directives
+
+    # Use valid regular expression syntax
     - valid_regexps
+
+    # DON'T assign to void
     - void_checks
 
-    # 
+    # Annotate overridden members
     - annotate_overrides
+
+    # AVOID using forEach with a function literal
+    # The for loop enables a developer to be clear and explicit as to their intent. 
+    # A return in the body of the for loop returns from the body of the function, where as a return in the body of the forEach closure only returns a value for that iteration of the forEach. 
+    # The body of a for loop can contain awaits, while the closure body of a forEach cannot.
     - avoid_function_literals_in_foreach_calls
+
+    # Adding = null is redundant and unneeded
     - avoid_init_to_null
+
+    # DON’T check for null in custom == operators
+    # As null is a special value, no instance of any class (other than Null) can be equivalent to it. Thus, it is redundant to check whether the other instance is null.
     - avoid_null_checks_in_equality_operators
+
+    # Don't rename parameters of overridden methods.
     - avoid_renaming_method_parameters
+
     - avoid_return_types_on_setters
     - avoid_returning_null_for_void
     - avoid_single_cascade_in_expression_statements
     - constant_identifier_names
+
+    # AVOID control flow leaving finally blocks. Using control flow in finally blocks will inevitably cause unexpected behavior that is hard to debug.
     - control_flow_in_finally
     - empty_constructor_bodies
     - empty_statements
+
+    # Define case clauses for all constants in enum-like classes.
     - exhaustive_cases
+
+    # DON’T import implementation files from another package.
     - implementation_imports
+
+    # Name libraries using lowercase_with_underscores
     - library_names
+
+    # Use lowercase_with_underscores when specifying a library prefix.
     - library_prefixes
-    - library_private_types_in_public_api
+
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+
+    # DON’T pass null as an argument where a closure is expected.
+    # Often a closure that is passed to a method will only be called conditionally, so that tests and “happy path” production calls do not reveal that null will result in an exception being thrown.
     - null_closures
+
+    # DON’T override fields.
+    # Overriding fields is almost always done unintentionally. Regardless, it is a bad practice to do so.
     - overridden_fields
+
+    # Use lowercase_with_underscores for package names.
     - package_names
+
+    # DO use adjacent strings to concatenate string literals.
     - prefer_adjacent_string_concatenation
+
+    # DO use collection literals when possible.
     - prefer_collection_literals
+
+    # Prefer using ??= over testing for null
     - prefer_conditional_assignment
+
+    # Use contains for List and String instances.
     - prefer_contains
+
+    # Private field could be final
     - prefer_final_fields
+
+    # Prefer 'for' elements when building maps from iterables.
     - prefer_for_elements_to_map_fromIterable
+
+    # DO use a function declaration to bind a function to a name.
+    # As Dart allows local function declarations, it is a good practice to use them in the place of function literals.
     - prefer_function_declarations_over_variables
+
+    # PREFER using if null operators instead of null checks in conditional expressions. 
     - prefer_if_null_operators
+
+    # DO use initializing formals when possible.
+    # Using initializing formals when possible makes your code more terse.
     - prefer_initializing_formals
+
+    # Inline list item declarations where possible.
     - prefer_inlined_adds
     - prefer_interpolation_to_compose_strings
+    
+    # Prefer is! operator.
     - prefer_is_not_operator
+
+    # PREFER using null aware operators instead of null checks in conditional expressions.
     - prefer_null_aware_operators
+
+    # Use spread collections when possible.
+    # Collection literals are excellent when you want to create a new collection out of individual items. But, when existing items are already stored in another collection, spread collection syntax leads to simpler code.
     - prefer_spread_collections
+
+    # DON’T create recursive getters. 
+    # Recursive getters are getters which return themselves as a value. This is usually a typo.
     - recursive_getters
+
+    # Prefer using /// for doc comments.
     - slash_for_doc_comments
+
+    # DON’T type annotate initializing formals.
     - type_init_formals
+
+    # Avoid using braces in interpolation when not needed.
     - unnecessary_brace_in_string_interps
     - unnecessary_const
     - unnecessary_constructor_name

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
-import 'Album.dart';
+import 'album.dart';
 
 class SpotifyAPI {
   //Initialise necessary variables from Spotify API

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -62,14 +62,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_lints:
-    dependency: "direct dev"
-    description:
-      name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -91,14 +83,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
-  lints:
-    dependency: transitive
-    description:
-      name: lints
-      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
+  # flutter_lints: ^2.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Description:

This PR aims to add custom `Linter Rules` to aid the developers to write clean and consistent code, by enforcing certain best practices specified by Google and Flutter team. 
* The linting rules are present in: `analysis_options.yaml`

[Reference for Rules](https://pub.dev/packages/lint)

Resolves #16  